### PR TITLE
Remove daemonize dependency to allow building on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,12 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-
-[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,16 +724,6 @@ dependencies = [
  "hostname",
  "lazy_static",
  "rand",
-]
-
-[[package]]
-name = "daemonize"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
-dependencies = [
- "boxfnonce",
- "libc",
 ]
 
 [[package]]
@@ -1611,7 +1595,6 @@ version = "0.1.6"
 dependencies = [
  "clap",
  "crossterm",
- "daemonize",
  "futures",
  "lofty",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ sea-orm = { version = "0.9.2", features = ["runtime-tokio-rustls", "sqlx-sqlite"
 futures = "0.3.24"
 lofty = "0.8.1"
 owo-colors = "3.5.0"
-daemonize = "0.4.1"
 tabled = "0.8.0"
 crossterm = { version = "0.25.0", features = ["serde"] }
 tui = { version = "0.19.0", features = ["crossterm", "serde"] }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This is a simple music player that I made for my own use. It is written in Rust 
 # Install dependencies
 brew install protobuf # macOS
 sudo apt-get install -y libasound2-dev protobuf-compiler # Ubuntu/Debian
+choco install protoc # Windows using Chocolatey Package Manager
 # Compile
 git clone https://github.com/tsirysndr/music-player.git
 cd music-player


### PR DESCRIPTION
The only thing keeping the project from building on Windows was the daemonize dependency, which wasn't being used. Unless you have future plans for it?