### PR TITLE
Fix Settings deserialization when settings.toml doesn't contain all the values in Settings

### DIFF
--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -55,5 +55,10 @@ pub fn read_settings() -> Result<Config, ConfigError> {
     Config::builder()
         .add_source(config::File::with_name(&settings_path))
         .add_source(config::Environment::with_prefix("MUSIC_PLAYER"))
+        .set_default("database_url", default_settings.database_url)?
+        .set_default("port", default_settings.port)?
+        .set_default("addons", default_settings.addons)?
+        .set_default("ws_port", default_settings.ws_port)?
+        .set_default("music_directory", default_settings.music_directory)?
         .build()
 }


### PR DESCRIPTION
If I already have a `music-player/settings.toml` file and upgrade to a newer version that includes new settings options, I was getting error like this at startup:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: missing field `ws_port`', D:\Users\Ben\Documents\Development\music-player\migration\src/lib.rs:19:57
```

This fixes it by adding default values to the Config. There might be a better way to fix it, I'm open to suggestions.