### PR TITLE
chore(scanner): update lofty to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,15 +2526,16 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863330a778316906983c07e225026b643b170502a96709dbfe6e6168bce53084"
+checksum = "8242df2d720c7f2e23bb7829da4447e5a762ccf0a361a01efe1433f554a48400"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
  "cfg-if 1.0.0",
  "flate2",
  "lofty_attr",
+ "log",
  "ogg_pager",
  "once_cell",
  "paste",
@@ -2542,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "lofty_attr"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d906642cda9ed88dfb98ece66d113c5dd73c490da5d11ba4554bf75d78383f8"
+checksum = "3d0d19de3efdb768ecdccb6e904eb4c089ee9c1b59684d09218802e16cae8cc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tokio = { version = "1.21.0", features = ["full"] }
 md5 = "0.7.0"
 sea-orm = { version = "0.9.2", features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 futures = "0.3.24"
-lofty = "0.8.1"
+lofty = "0.9.0"
 owo-colors = "3.5.0"
 tabled = "0.8.0"
 crossterm = { version = "0.25.0", features = ["serde"] }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.1.0"
 
 [dependencies]
 dirs = "4.0.0"
-lofty = "0.8.1"
+lofty = "0.9.0"
 mime_guess = "2.0.4"
 walkdir = "2.3.2"
 sea-orm = { version = "0.9.2", features = ["runtime-tokio-rustls", "sqlx-sqlite"] }

--- a/scanner/src/lib.rs
+++ b/scanner/src/lib.rs
@@ -35,7 +35,7 @@ pub async fn scan_directory(
         {
             match Probe::open(&path)
                 .expect("ERROR: Bad path provided!")
-                .read(true)
+                .read()
             {
                 Ok(tagged_file) => {
                     let tag = match tagged_file.primary_tag() {


### PR DESCRIPTION
The changelog is available [here](https://github.com/Serial-ATA/lofty-rs/blob/main/CHANGELOG.md#090---2022-10-30).