### PR TITLE
docs: fix typos

### DIFF
--- a/addons/src/chromecast.rs
+++ b/addons/src/chromecast.rs
@@ -257,7 +257,7 @@ impl<'a> Player for Chromecast<'a> {
         tracks: Vec<Track>,
         start_index: Option<i32>,
     ) -> Result<(), Error> {
-        let medias = tracks
+        let media = tracks
             .iter()
             .map(|track| Media {
                 content_id: track.uri.clone(),
@@ -289,12 +289,12 @@ impl<'a> Player for Chromecast<'a> {
         if let Some(cast_device) = &self.client {
             cast_device.media.queue_load(
                 transport_id,
-                medias.clone(),
+                media.clone(),
                 Some(start_index.unwrap_or(0)),
                 None,
             )?;
             println!("[chromecast] Tracks loaded");
-            println!("[chromecast] Playing track {:#?}", medias[0]);
+            println!("[chromecast] Playing track {:#?}", media[0]);
             return Ok(());
         }
 

--- a/addons/src/dlna.rs
+++ b/addons/src/dlna.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crate::{Addon, Browseable, Player};
+use crate::{Addon, Browsable, Player};
 use anyhow::Error;
 use async_trait::async_trait;
 use music_player_tracklist::Tracklist;
@@ -77,7 +77,7 @@ impl Dlna {
 
     pub fn connect_to_media_server(
         device: Device,
-    ) -> Result<Option<Box<dyn Browseable + Send>>, Error> {
+    ) -> Result<Option<Box<dyn Browsable + Send>>, Error> {
         let mut player: Self = device.clone().into();
         let location = player.location.clone().unwrap();
         let device_client = futures::executor::block_on(DeviceClient::new(&location)?.connect())?;
@@ -113,7 +113,7 @@ impl Addon for Dlna {
 }
 
 #[async_trait]
-impl Browseable for Dlna {
+impl Browsable for Dlna {
     async fn albums(
         &mut self,
         filter: Option<String>,

--- a/addons/src/kodi.rs
+++ b/addons/src/kodi.rs
@@ -3,7 +3,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use music_player_types::types::{Album, Artist, Device, Playback, Playlist, Track, XBMC_DEVICE};
 
-use super::{Addon, Browseable, Player, StreamingAddon};
+use super::{Addon, Browsable, Player, StreamingAddon};
 
 pub struct Client {
     pub host: String,
@@ -74,7 +74,7 @@ impl StreamingAddon for Kodi {
 }
 
 #[async_trait]
-impl Browseable for Kodi {
+impl Browsable for Kodi {
     async fn albums(
         &mut self,
         filter: Option<String>,

--- a/addons/src/lib.rs
+++ b/addons/src/lib.rs
@@ -31,7 +31,7 @@ pub trait LyricsAddon {
 }
 
 #[async_trait]
-pub trait Browseable {
+pub trait Browsable {
     async fn albums(
         &mut self,
         filter: Option<String>,
@@ -82,7 +82,7 @@ pub trait Player {
 }
 
 pub struct CurrentSourceDevice {
-    pub client: Option<Box<dyn Browseable + Send>>,
+    pub client: Option<Box<dyn Browsable + Send>>,
     pub source_device: Option<Device>,
 }
 
@@ -94,7 +94,7 @@ impl CurrentSourceDevice {
         }
     }
 
-    pub fn set_client(&mut self, client: Box<dyn Browseable + Send>) {
+    pub fn set_client(&mut self, client: Box<dyn Browsable + Send>) {
         self.client = Some(client);
     }
 
@@ -156,7 +156,7 @@ impl CurrentReceiverDevice {
 }
 
 pub struct CurrentDevice {
-    pub source: Option<Box<dyn Browseable + Send>>,
+    pub source: Option<Box<dyn Browsable + Send>>,
     pub receiver: Option<Box<dyn Player + Send>>,
     pub source_device: Option<Device>,
     pub receiver_device: Option<Device>,
@@ -172,7 +172,7 @@ impl CurrentDevice {
         }
     }
 
-    pub fn set_source(&mut self, source: Box<dyn Browseable + Send>) {
+    pub fn set_source(&mut self, source: Box<dyn Browsable + Send>) {
         self.source = Some(source);
     }
 

--- a/addons/src/local.rs
+++ b/addons/src/local.rs
@@ -1,4 +1,4 @@
-use super::{Addon, Browseable, Player, StreamingAddon};
+use super::{Addon, Browsable, Player, StreamingAddon};
 use anyhow::{Error, Ok};
 use async_trait::async_trait;
 use music_player_client::{
@@ -77,7 +77,7 @@ impl StreamingAddon for Local {
 }
 
 #[async_trait]
-impl Browseable for Local {
+impl Browsable for Local {
     async fn albums(
         &mut self,
         filter: Option<String>,

--- a/audio/src/fetch/receive.rs
+++ b/audio/src/fetch/receive.rs
@@ -133,7 +133,7 @@ impl AudioFileFetch {
             let length = min(range.length, bytes);
             self.download_range(offset, length)?;
         } else if !missing_data.is_empty() {
-            // ok, the tail is downloaded, download something fom the beginning.
+            // ok, the tail is downloaded, download something from the beginning.
             let range = missing_data.get_range(0);
             let offset = range.start;
             let length = min(range.length, bytes);

--- a/graphql/src/schema/mod.rs
+++ b/graphql/src/schema/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Error;
 use async_graphql::{Enum, MergedObject, MergedSubscription};
 use music_player_addons::{
-    airplay::Airplay, chromecast::Chromecast, dlna::Dlna, kodi::Kodi, local::Local, Browseable,
+    airplay::Airplay, chromecast::Chromecast, dlna::Dlna, kodi::Kodi, local::Local, Browsable,
     Player,
 };
 use music_player_types::types::Device;
@@ -66,7 +66,7 @@ pub enum MutationType {
     Updated,
 }
 
-pub async fn connect_to(device: Device) -> Result<Option<Box<dyn Browseable + Send>>, Error> {
+pub async fn connect_to(device: Device) -> Result<Option<Box<dyn Browsable + Send>>, Error> {
     let mut local: Local = device.clone().into();
     local.connect().await?;
     Ok(Some(Box::new(local)))

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -133,7 +133,7 @@ pub fn draw_input<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
     B: Backend,
 {
-    // Check for the width and change the contraints accordingly
+    // Check for the width and change the constraints accordingly
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(100), Constraint::Percentage(10)].as_ref())
@@ -673,7 +673,7 @@ fn draw_table<B>(
     f: &mut Frame<B>,
     app: &App,
     layout_chunk: Rect,
-    table_layout: (&str, &TableHeader), // (title, header colums)
+    table_layout: (&str, &TableHeader), // (title, header columns)
     items: &[TableItem], // The nested vector must have the same length as the `header_columns`
     selected_index: usize,
     highlight_state: (bool, bool),


### PR DESCRIPTION
Found via `codespell -S webui,*.svg -L crate`